### PR TITLE
Attempting to fix async mouse hanging

### DIFF
--- a/libasyncmouse.asyncmouse.pas
+++ b/libasyncmouse.asyncmouse.pas
@@ -84,7 +84,7 @@ procedure TASyncMouseThread.Execute;
 
     while Moving do
     begin
-      if GetTickCount() > t + 15000 then
+      if GetTickCount() > (t + 15000) then
       begin
         WriteLn('Something went wrong. AsyncMouse movement did not complete in 15 seconds.');
         Break;

--- a/libasyncmouse.asyncmouse.pas
+++ b/libasyncmouse.asyncmouse.pas
@@ -70,6 +70,7 @@ procedure TASyncMouseThread.Execute;
     x, y: Double;
     veloX, veloY, windX, windY, veloMag, randomDist, step, idle: Double;
     traveledDistance, remainingDistance: Double;
+    t: UInt64;
   begin
     windX := 0;
     windY := 0;
@@ -79,8 +80,16 @@ procedure TASyncMouseThread.Execute;
     x := Position.X;
     y := Position.Y;
 
+    t := GetTickCount();
+
     while Moving do
     begin
+      if GetTickCount() > t + 15000 then
+      begin
+        WriteLn('Something went wrong. AsyncMouse movement did not complete in 15 seconds.');
+        Break;
+      end;
+
       traveledDistance := Hypot(x - Position.X, y - Position.Y);
       remainingDistance := Hypot(x - Destination.X, y - Destination.Y);
       if (remainingDistance <= Max(1, Accuracy)) then


### PR DESCRIPTION
Hi @ollydev ,

So, this is the first time I'm touching a plugin and this might be all wrong but I would assume it's fine.
As I've mention sometimes in the past, both me and Flight have had issues with AsyncMouse where it just hangs forever, after taking a look at this, I think the issue might be what this PR attempts to solve.
I've basically just added the same timeout that SRL `TMouse.WindMouse()` has to this.

I've made some assumptions that might be wrong:
- I assumed I can use `GetTickCount()`
- I assumed I can use `WriteLn()`

Feel free to modify this as you see fit or scrap it altogether if this is not the reason the hanging happens